### PR TITLE
feat: 게시글 상세 페이지 수정&삭제 관련 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react": "^18",
     "react-dom": "^18",
     "next": "14.2.28",
-    "sass": "^1.87.0"
+    "sass": "^1.87.0",
+    "zustand": "^5.0.4"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       sass:
         specifier: ^1.87.0
         version: 1.87.0
+      zustand:
+        specifier: ^5.0.4
+        version: 5.0.4(@types/react@18.3.20)(react@18.3.1)
     devDependencies:
       '@types/node':
         specifier: ^20
@@ -1658,6 +1661,24 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zustand@5.0.4:
+    resolution: {integrity: sha512-39VFTN5InDtMd28ZhjLyuTnlytDr9HfwO512Ai4I8ZABCoyAj4F1+sr7sD1jP/+p7k77Iko0Pb5NhgBFDCX0kQ==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -3519,3 +3540,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   yocto-queue@0.1.0: {}
+
+  zustand@5.0.4(@types/react@18.3.20)(react@18.3.1):
+    optionalDependencies:
+      '@types/react': 18.3.20
+      react: 18.3.1

--- a/src/app/post/write/[id]/page.tsx
+++ b/src/app/post/write/[id]/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import Write from '@/features/write';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+export default function PostWritePage() {
+  const queryClient = new QueryClient();
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Write />
+    </QueryClientProvider>
+  );
+}

--- a/src/features/auth/Auth/index.tsx
+++ b/src/features/auth/Auth/index.tsx
@@ -37,6 +37,7 @@ export default function Auth() {
         onSuccess: (data) => {
           localStorage.setItem('accessToken', data.tokens.accessToken);
           localStorage.setItem('refreshToken', data.tokens.refreshToken);
+          localStorage.setItem('userId', data.user.id);
           router.replace('/');
         },
         onError: (error) => {

--- a/src/features/auth/Auth/index.tsx
+++ b/src/features/auth/Auth/index.tsx
@@ -2,6 +2,7 @@
 
 import Button from '@/features/ui/Button/Button';
 import { useLogin } from '@/globalState/tanstackQueryHooks/Login';
+import { useMyInfoStore } from '@/globalState/zusatnd/useMyInfoStore';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import styles from './index.module.scss';
@@ -13,6 +14,7 @@ export default function Auth() {
   const [passwordError, setPasswordError] = useState<boolean>(false);
   const router = useRouter();
   const { mutate } = useLogin();
+  const setUserId = useMyInfoStore((state) => state.setUserId);
 
   useEffect(() => {
     const accessToken = localStorage.getItem('accessToken');
@@ -37,7 +39,7 @@ export default function Auth() {
         onSuccess: (data) => {
           localStorage.setItem('accessToken', data.tokens.accessToken);
           localStorage.setItem('refreshToken', data.tokens.refreshToken);
-          localStorage.setItem('userId', data.user.id);
+          setUserId(data.user.id);
           router.replace('/');
         },
         onError: (error) => {

--- a/src/features/communityDetail/postComment/index.module.scss
+++ b/src/features/communityDetail/postComment/index.module.scss
@@ -19,6 +19,46 @@
       gap: 8px;
     }
 
+    &__actions {
+      display: flex;
+      gap: 12px;
+
+      &__edit,
+      &__delete,
+      &__save,
+      &__cancel {
+        @include typography(Body-2);
+        color: #a7a9b4;
+        background: none;
+        border: none;
+        padding: 0;
+        cursor: pointer;
+      }
+    }
+
+    &__top {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 8px;
+    }
+
+    &__editTextarea {
+      width: 100%;
+      min-height: 40px;
+      padding: 8px;
+      border: 1px solid #eeeff1;
+      border-radius: 4px;
+      resize: none;
+      font-family: inherit;
+      font-size: inherit;
+      line-height: 1.5;
+
+      &:focus {
+        outline: none;
+      }
+    }
+
     &__createdAt {
       color: #a7a9b4;
     }

--- a/src/features/communityDetail/postComment/index.tsx
+++ b/src/features/communityDetail/postComment/index.tsx
@@ -7,6 +7,7 @@ import {
   useDeleteCommunityPostComment,
   useUpdateCommunityPostComment,
 } from '@/globalState/tanstackQueryHooks/communityList';
+import { useMyInfoStore } from '@/globalState/zusatnd/useMyInfoStore';
 import Image from 'next/image';
 import { useParams } from 'next/navigation';
 import { useState } from 'react';
@@ -21,8 +22,7 @@ export default function PostComment({ comments }: CommentProps) {
   const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
   const [editContent, setEditContent] = useState<string>('');
   const { id } = useParams();
-  const myUserId =
-    typeof window !== 'undefined' ? localStorage.getItem('userId') : null;
+  const userId = useMyInfoStore((state) => state.userId);
 
   const { mutate: createComment } = useCreateCommunityPostComment(id as string);
   const { mutate: deleteComment } = useDeleteCommunityPostComment(id as string);
@@ -54,7 +54,7 @@ export default function PostComment({ comments }: CommentProps) {
                 />
                 {comment.user.nickname || '익명유저'}
               </div>
-              {comment.user.id === myUserId && (
+              {comment.user.id === userId && (
                 <div className={styles.container__comment__actions}>
                   {editingCommentId === comment.id ? (
                     <>
@@ -132,6 +132,7 @@ export default function PostComment({ comments }: CommentProps) {
             createComment(content);
             setContent('');
           }}
+          disabled={!userId}
         >
           등록
         </Button>

--- a/src/features/communityDetail/postComment/index.tsx
+++ b/src/features/communityDetail/postComment/index.tsx
@@ -21,6 +21,8 @@ export default function PostComment({ comments }: CommentProps) {
   const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
   const [editContent, setEditContent] = useState<string>('');
   const { id } = useParams();
+  const myUserId =
+    typeof window !== 'undefined' ? localStorage.getItem('userId') : null;
 
   const { mutate: createComment } = useCreateCommunityPostComment(id as string);
   const { mutate: deleteComment } = useDeleteCommunityPostComment(id as string);
@@ -52,50 +54,52 @@ export default function PostComment({ comments }: CommentProps) {
                 />
                 {comment.user.nickname || '익명유저'}
               </div>
-              <div className={styles.container__comment__actions}>
-                {editingCommentId === comment.id ? (
-                  <>
-                    <button
-                      className={styles.container__comment__actions__save}
-                      onClick={() => {
-                        updateComment({
-                          commentId: comment.id,
-                          content: editContent,
-                        });
-                        setEditingCommentId(null);
-                        setEditContent('');
-                      }}
-                    >
-                      저장
-                    </button>
-                    <button
-                      className={styles.container__comment__actions__cancel}
-                      onClick={handleCancelEdit}
-                    >
-                      취소
-                    </button>
-                  </>
-                ) : (
-                  <>
-                    <button
-                      className={styles.container__comment__actions__edit}
-                      onClick={() => handleEditClick(comment)}
-                    >
-                      수정
-                    </button>
-                    <button
-                      className={styles.container__comment__actions__delete}
-                      onClick={() => {
-                        if (confirm('댓글을 삭제하시겠습니까?')) {
-                          deleteComment(comment.id);
-                        }
-                      }}
-                    >
-                      삭제
-                    </button>
-                  </>
-                )}
-              </div>
+              {comment.user.id === myUserId && (
+                <div className={styles.container__comment__actions}>
+                  {editingCommentId === comment.id ? (
+                    <>
+                      <button
+                        className={styles.container__comment__actions__save}
+                        onClick={() => {
+                          updateComment({
+                            commentId: comment.id,
+                            content: editContent,
+                          });
+                          setEditingCommentId(null);
+                          setEditContent('');
+                        }}
+                      >
+                        저장
+                      </button>
+                      <button
+                        className={styles.container__comment__actions__cancel}
+                        onClick={handleCancelEdit}
+                      >
+                        취소
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <button
+                        className={styles.container__comment__actions__edit}
+                        onClick={() => handleEditClick(comment)}
+                      >
+                        수정
+                      </button>
+                      <button
+                        className={styles.container__comment__actions__delete}
+                        onClick={() => {
+                          if (confirm('댓글을 삭제하시겠습니까?')) {
+                            deleteComment(comment.id);
+                          }
+                        }}
+                      >
+                        삭제
+                      </button>
+                    </>
+                  )}
+                </div>
+              )}
             </div>
             {editingCommentId === comment.id ? (
               <textarea

--- a/src/features/communityDetail/postHeader/index.module.scss
+++ b/src/features/communityDetail/postHeader/index.module.scss
@@ -12,22 +12,43 @@
     margin-bottom: 16px;
   }
 
-  &__meta {
+  &__bottom {
     display: flex;
+    justify-content: space-between;
     align-items: center;
 
-    &__username {
-      @include typography(Body-2);
-      color: #a7a9b4;
+    &__meta {
+      display: flex;
+      align-items: center;
+
+      &__username {
+        @include typography(Body-2);
+        color: #a7a9b4;
+      }
+
+      &__createdAt {
+        @include typography(Body-2);
+        color: #a7a9b4;
+      }
+
+      &__separator {
+        margin: 0 12px;
+      }
     }
 
-    &__createdAt {
-      @include typography(Body-2);
-      color: #a7a9b4;
-    }
+    &__actions {
+      display: flex;
+      gap: 12px;
 
-    &__separator {
-      margin: 0 12px;
+      &__edit,
+      &__delete {
+        @include typography(Body-2);
+        color: #a7a9b4;
+        background: none;
+        border: none;
+        padding: 0;
+        cursor: pointer;
+      }
     }
   }
 }

--- a/src/features/communityDetail/postHeader/index.tsx
+++ b/src/features/communityDetail/postHeader/index.tsx
@@ -1,31 +1,63 @@
 'use client';
 
-import { CommunityPost } from '@/globalState/tanstackQueryHooks/communityList';
+import {
+  CommunityPost,
+  useDeleteCommunityPost,
+} from '@/globalState/tanstackQueryHooks/communityList';
 import Image from 'next/image';
 import styles from './index.module.scss';
+import { useRouter } from 'next/navigation';
 
 interface PostHeaderProps {
   post: CommunityPost | undefined;
 }
 
 export default function PostHeader({ post }: PostHeaderProps) {
+  const { mutate: deletePost } = useDeleteCommunityPost(post?.id as string);
+  const router = useRouter();
+
   return (
     <div className={styles.container}>
       <div className={styles.container__title}>{post?.title}</div>
-      <div className={styles.container__meta}>
-        <span className={styles.container__meta__username}>
-          {post?.author?.nickname}
-        </span>
-        <Image
-          src={'/images/community-detail/separator.svg'}
-          className={styles.container__meta__separator}
-          alt="profile"
-          width={2}
-          height={20}
-        />
-        <span className={styles.container__meta__createdAt}>
-          {post?.createdAt?.slice(2, 10).replace(/-/g, '.')}
-        </span>
+      <div className={styles.container__bottom}>
+        <div className={styles.container__bottom__meta}>
+          <span className={styles.container__bottom__meta__username}>
+            {post?.author?.nickname || '익명유저'}
+          </span>
+          <Image
+            src={'/images/community-detail/separator.svg'}
+            className={styles.container__bottom__meta__separator}
+            alt="profile"
+            width={2}
+            height={20}
+          />
+          <span className={styles.container__bottom__meta__createdAt}>
+            {post?.createdAt?.slice(2, 10).replace(/-/g, '.')}
+          </span>
+        </div>
+        {post?.isAuthor && (
+          <div className={styles.container__bottom__actions}>
+            <button
+              className={styles.container__bottom__actions__edit}
+              onClick={() => {
+                router.push(`/post/write/${post?.id}`);
+              }}
+            >
+              수정
+            </button>
+            <button
+              className={styles.container__bottom__actions__delete}
+              onClick={() => {
+                if (confirm('게시글을 삭제하시겠습니까?')) {
+                  deletePost();
+                  router.push('/');
+                }
+              }}
+            >
+              삭제
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/features/write/index.module.scss
+++ b/src/features/write/index.module.scss
@@ -13,7 +13,7 @@
 
   &__wrapper {
     margin: 0 auto;
-    max-width: 1000px;
+    max-width: 1200px;
     padding: 24px 24px 24px 24px;
     background-color: #fff;
     border: 1px solid #eeeff1;

--- a/src/globalState/tanstackQueryHooks/Login.ts
+++ b/src/globalState/tanstackQueryHooks/Login.ts
@@ -7,6 +7,15 @@ type LoginResponse = {
     accessToken: string;
     refreshToken: string;
   };
+  user: {
+    loginId: string;
+    profileImageUrl: string;
+    createdAt: string;
+    updatedAt: string;
+    deletedAt: string;
+    id: string;
+    nickname: string;
+  };
 };
 
 export const useLogin = () => {

--- a/src/globalState/tanstackQueryHooks/communityList.ts
+++ b/src/globalState/tanstackQueryHooks/communityList.ts
@@ -6,6 +6,8 @@ import {
 } from '@tanstack/react-query';
 import { fetcher } from '@/lib/tanstackQuery/fetcher';
 import { post } from '@/lib/tanstackQuery/post';
+import { apiCaller } from '@/apis';
+import { API_URL } from '@/constants/env';
 
 export interface CommunityPost {
   author: {
@@ -93,4 +95,10 @@ export const useCreateCommunityPost = (
     post<CommunityPost>('api/posts', { title, content });
 
   return useMutation({ mutationFn: api, ...options });
+};
+
+export const useDeleteCommunityPost = (id: string) => {
+  const api = () => apiCaller.delete(`api/posts/${id}`);
+
+  return useMutation({ mutationFn: api });
 };

--- a/src/globalState/tanstackQueryHooks/communityList.ts
+++ b/src/globalState/tanstackQueryHooks/communityList.ts
@@ -1,13 +1,14 @@
+import { apiCaller } from '@/apis';
 import { queryKeys } from '@/constants/query.keys';
+import { fetcher } from '@/lib/tanstackQuery/fetcher';
+import { patch } from '@/lib/tanstackQuery/patch';
+import { post } from '@/lib/tanstackQuery/post';
 import {
   useMutation,
   UseMutationOptions,
   useQuery,
+  useQueryClient,
 } from '@tanstack/react-query';
-import { fetcher } from '@/lib/tanstackQuery/fetcher';
-import { post } from '@/lib/tanstackQuery/post';
-import { apiCaller } from '@/apis';
-import { API_URL } from '@/constants/env';
 
 export interface CommunityPost {
   author: {
@@ -79,11 +80,20 @@ export const useGetCommunityPostComments = (id: string) => {
 };
 
 export const useCreateCommunityPostComment = (id: string) => {
+  const queryClient = useQueryClient();
   const api = (content: string) =>
     post<CommunityPostComment>(`api/posts/${id}/comments`, { content });
 
-  return useMutation({ mutationFn: api });
+  return useMutation({
+    mutationFn: api,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [queryKeys.community.post, id, 'comments'],
+      });
+    },
+  });
 };
+
 export const useCreateCommunityPost = (
   options?: UseMutationOptions<
     CommunityPost,
@@ -101,4 +111,39 @@ export const useDeleteCommunityPost = (id: string) => {
   const api = () => apiCaller.delete(`api/posts/${id}`);
 
   return useMutation({ mutationFn: api });
+};
+
+export const useDeleteCommunityPostComment = (id: string) => {
+  const queryClient = useQueryClient();
+  const api = (commentId: string) =>
+    apiCaller.delete(`api/posts/${id}/comments/${commentId}`);
+
+  return useMutation({
+    mutationFn: api,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [queryKeys.community.post, id, 'comments'],
+      });
+    },
+  });
+};
+
+export const useUpdateCommunityPostComment = (id: string) => {
+  const queryClient = useQueryClient();
+  const api = ({
+    commentId,
+    content,
+  }: {
+    commentId: string;
+    content: string;
+  }) => patch(`api/posts/${id}/comments/${commentId}`, { content });
+
+  return useMutation({
+    mutationFn: api,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [queryKeys.community.post, id, 'comments'],
+      });
+    },
+  });
 };

--- a/src/globalState/zusatnd/useMyInfoStore.ts
+++ b/src/globalState/zusatnd/useMyInfoStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface MyInfoState {
+  userId: string | null;
+  setUserId: (userId: string | null) => void;
+}
+
+export const useMyInfoStore = create<MyInfoState>((set) => ({
+  userId: null,
+  setUserId: (userId) => set({ userId }),
+}));

--- a/src/lib/tanstackQuery/patch.ts
+++ b/src/lib/tanstackQuery/patch.ts
@@ -1,0 +1,16 @@
+import { AxiosRequestConfig } from 'axios';
+import { apiCaller } from '@/apis';
+
+export async function patch<T, F = unknown>(
+  path: string,
+  payload?: any,
+  params?: AxiosRequestConfig<F>,
+) {
+  try {
+    const response = await apiCaller.patch<T>(path, payload, params);
+    return response.data;
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+}


### PR DESCRIPTION
## 변경사항
### 게시글 상세 수정 & 삭제 기능 구현
|게시글 상세 페이지|
|----------------|
|<img width="1330" alt="Screenshot 2025-05-06 at 07 21 28" src="https://github.com/user-attachments/assets/a8ef446b-09b0-456d-90d6-b0dfa9b4f209" />|

### 댓글 수정 기능 구현
|댓글 수정|구현 UI|
|-------|-------|
|<img width="1234" alt="Screenshot 2025-05-06 at 07 22 54" src="https://github.com/user-attachments/assets/61d679ad-521c-44d7-8d5d-9f51cf7cf557" />|<img width="1244" alt="Screenshot 2025-05-06 at 07 23 08" src="https://github.com/user-attachments/assets/211f9d5c-a395-49c7-9bc4-26538dcec73f" />|

### 게시글 수정 페이지 구현
- 변경사항이 없을 시 버튼이 disabled 처리되도록 구현

|게시글 수정 페이지(변경사항 없을 시)|
|--------------------------------|
|<img width="1272" alt="Screenshot 2025-05-06 at 07 24 36" src="https://github.com/user-attachments/assets/c1679024-ad05-4bdf-b70d-cf1c1af409d8" />|

### userId 전역 상태 관리 로직 추가
- zustand를 활용하여 userId를 전역적으로 관리하도록 구현

## 전달 사항
- 현재 API 설계상 게시글 상세 조회는 인증 유저만 가능하도록 되어 있습니다.
- 비로그인 사용자의 게시글 상세 조회가 필요하다면, 백엔드 API에서 인증 없이도 게시글 상세를 조회할 수 있도록 수정이 필요합니다.
- 프론트엔드에서는 "비로그인 상태일 경우 댓글 작성 버튼 비활성화" 등 관련 UI 처리는 완료된 상태입니다.